### PR TITLE
Add dev container workspace as Git safe directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,31 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
-	"name": "Rust",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm"
+  "name": "Rust",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm"
 
-	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
+  // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+  // "mounts": [
+  // 	{
+  // 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+  // 		"target": "/usr/local/cargo",
+  // 		"type": "volume"
+  // 	}
+  // ]
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "rustc --version",
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Rust",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
 
   // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
   // "mounts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,10 +39,30 @@
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root",
 
-  // Use `postCreateCommand` to run commands after the container is created.
-  // "postCreateCommand": "rustc --version",
+  // Use `initializeCommand` to run commands on the **host** machine before
+  // the container is created. (**Note:** Do not try to access `${containerEnv}`
+  // variables until after the `initializeCommand` event.)
+  "initializeCommand": "echo @initializeCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, workspace: ${containerWorkspaceFolder}",
+
+  // Use `onCreateCommand` to run commands **inside** the container after
+  // it has started for the first time.
+  "onCreateCommand": "echo @onCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
+
+  // Use `updateContentCommand` to run commands **inside** the container
+  // after `onCreateCommand`, whenever new content is available in the source
+  // tree during the creation process.
+  "updateContentCommand": "echo @updateContentCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
+
+  // Use `postCreateCommand` to run commands **inside** the container
+  // after `updateContentCommand`, once the dev container has been assigned
+  // to a user for the first time.
+  "postCreateCommand": "echo @postCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}, $(rustc --version)",
 
   // Use `postStartCommand` to run commands **inside** the container each time
   // it is successfully started.
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+
+  // Use `postAttachCommand` to run commands **inside** the container each time
+  // a tool has successfully attached to the container.
+  "postAttachCommand": "echo @postAttachCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,20 @@
   "features": {},
 
   // Configure tool-specific properties.
-  "customizations": {},
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      "extensions": [
+        "davidanson.vscode-markdownlint",
+        "esbenp.prettier-vscode",
+        "docsmsft.docs-authoring-pack",
+        "rust-lang.rust-analyzer",
+        "serayuzgur.crates",
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  },
 
   // Use `forwardPorts` to make a list of ports inside the container available locally.
   "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,27 +42,27 @@
   // Use `initializeCommand` to run commands on the **host** machine before
   // the container is created. (**Note:** Do not try to access `${containerEnv}`
   // variables until after the `initializeCommand` event.)
-  "initializeCommand": "echo @initializeCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, workspace: ${containerWorkspaceFolder}",
+  // "initializeCommand": "echo @initializeCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, workspace: ${containerWorkspaceFolder}",
 
   // Use `onCreateCommand` to run commands **inside** the container after
   // it has started for the first time.
-  "onCreateCommand": "echo @onCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
+  // "onCreateCommand": "echo @onCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
 
   // Use `updateContentCommand` to run commands **inside** the container
   // after `onCreateCommand`, whenever new content is available in the source
   // tree during the creation process.
-  "updateContentCommand": "echo @updateContentCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
+  // "updateContentCommand": "echo @updateContentCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}",
 
   // Use `postCreateCommand` to run commands **inside** the container
   // after `updateContentCommand`, once the dev container has been assigned
   // to a user for the first time.
-  "postCreateCommand": "echo @postCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}, $(rustc --version)",
+  // "postCreateCommand": "echo @postCreateCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}, $(rustc --version)",
 
   // Use `postStartCommand` to run commands **inside** the container each time
   // it is successfully started.
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 
   // Use `postAttachCommand` to run commands **inside** the container each time
   // a tool has successfully attached to the container.
-  "postAttachCommand": "echo @postAttachCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}"
+  // "postAttachCommand": "echo @postAttachCommand, devcontainerId: ${devcontainerId}, local, user: ${localEnv:USER}${localEnv:USERNAME}, workspace: ${localWorkspaceFolder}, container, user: ${containerEnv:USER:'<undefined>'}, workspace: ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Rust",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm"
+  "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
 
   // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
   // "mounts": [
@@ -28,4 +28,8 @@
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
+
+  // Use `postStartCommand` to run commands **inside** the container each time
+  // it is successfully started.
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
 
-  // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+  // Use `mounts` to make the cargo cache persistent in a Docker Volume.
   // "mounts": [
   // 	{
   // 		"source": "devcontainer-cargo-cache-${devcontainerId}",
@@ -15,19 +15,19 @@
   // ]
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
-
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
-
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "rustc --version",
+  "features": {},
 
   // Configure tool-specific properties.
-  // "customizations": {},
+  "customizations": {},
+
+  // Use `forwardPorts` to make a list of ports inside the container available locally.
+  "forwardPorts": [],
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
+  // "remoteUser": "root",
+
+  // Use `postCreateCommand` to run commands after the container is created.
+  // "postCreateCommand": "rustc --version",
 
   // Use `postStartCommand` to run commands **inside** the container each time
   // it is successfully started.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -1,3 +1,5 @@
 words:
+  - devcontainer
+  - devcontainers
   - rustlang
   - struct


### PR DESCRIPTION
- add the workspace to the devcontainer Git safe directory from the `postStartCommand` lifecycle event
- add stubs for all devcontainer lifecycle events, but left unused events commented out
- add VS Code extensions
  - opinionated extensions that help all developers maintain the code should be part of the devcontainer config
  - opinionated and unopinionated extensions should be in the VS Code `extensions.json`
 - cleanup `devcontainer.json` format/layout/style